### PR TITLE
fix(avx): workaround for missing _mm256_set_m128i in GCC

### DIFF
--- a/src/kern/optimized/x86/optimized_x86.h
+++ b/src/kern/optimized/x86/optimized_x86.h
@@ -206,7 +206,11 @@ inline float vec_vec_dot_q40_with_q80(const int n, const void* __restrict vx,
         }
 
         // Convert int32_t to float
+#if !defined(__GNUC__) || defined(__INTEL_COMPILER)
         __m256 p = _mm256_cvtepi32_ps( _mm256_set_m128i( i32[0], i32[1] ));
+#else
+        __m256 p = _mm256_cvtepi32_ps( _mm256_insertf128_si256( _mm256_castsi128_si256( i32[1] ), i32[0], 1 ));
+#endif
         // Apply the scale, and accumulate
         acc = _mm256_add_ps(_mm256_mul_ps( d, p ), acc);
     }


### PR DESCRIPTION

![image](https://github.com/MegEngine/InferLLM/assets/13466943/2eaf85e2-7766-4791-994d-50e84a25e126)

Follow this workaround (https://github.com/opencv/opencv/pull/8080) to successfully compile this project if `_mm256_setr_m128i` is unavailable.

The script I used to evaluate that the two expressions are equivalent:
```cpp
// Copyright [2023-05-29] <sxc19@mails.tsinghua.edu.cn, Xingchen Song>
#include <iostream>
#include <immintrin.h>

int main() {
    // Sample input data
    __m128i i32[2];
    i32[0] = _mm_set_epi32(4, 3, 2, 1);
    i32[1] = _mm_set_epi32(8, 7, 6, 5);

    // Evaluate the first expression
    __m256 result1 = _mm256_cvtepi32_ps(_mm256_set_m128i(i32[0], i32[1]));

    // Evaluate the second expression
    __m256 result2 = _mm256_cvtepi32_ps(_mm256_insertf128_si256(_mm256_castsi128_si256(i32[1]), i32[0], 1));

    // Compare the results element-wise
    bool equal = true;
    for (int i = 0; i < 8; ++i) {
        printf("result1[%d] = %f, result2[%d] = %f\n", i, result1[i], i, result2[i]);
        if (result1[i] != result2[i]) {
            equal = false;
            break;
        }
    }

    // Print the comparison result
    if (equal) {
        std::cout << "The two expressions are equivalent." << std::endl;
    } else {
        std::cout << "The two expressions are not equivalent." << std::endl;
    }

    return 0;
}
```

![image](https://github.com/MegEngine/InferLLM/assets/13466943/bd93315e-7e6a-436a-ac98-8d914f848b2e)
