### PR TITLE
Fixed an undefined variable in a optimized_x86.h file

### DIFF
--- a/src/kern/optimized/x86/optimized_x86.h
+++ b/src/kern/optimized/x86/optimized_x86.h
@@ -165,7 +165,7 @@ inline float vec_vec_dot_q40_with_q80(
 #if defined(__FMA__)
         acc = _mm256_fmadd_ps(d, q, acc);
 #else
-        acc = _mm256_add_ps(_mm256_mul_ps(d, p), acc);
+        acc = _mm256_add_ps(_mm256_mul_ps(d, q), acc);
 #endif
     }
 


### PR DESCRIPTION
[ 39%] Building CXX object CMakeFiles/InferLLMShared.dir/src/kern/naive/naive.cpp.o
[ 42%] Building CXX object CMakeFiles/InferLLM.dir/src/core/kvstotage.cpp.o
[ 44%] Building CXX object CMakeFiles/InferLLMShared.dir/src/kern/optimized/kernel_opt.cpp.o
[ 47%] Building CXX object CMakeFiles/InferLLMShared.dir/src/utils.cpp.o
[ 50%] Building CXX object CMakeFiles/InferLLM.dir/src/core/model.cpp.o
In file included from /mnt/Downloads/InferLLM/src/kern/optimized/kernel_opt.cpp:10:
/mnt/Downloads/InferLLM/src/kern/optimized/x86/optimized_x86.h: In function ‘float inferllm::opt::vec_vec_dot_q40_with_q80(int, const void*, const void*)’:
/mnt/Downloads/InferLLM/src/kern/optimized/x86/optimized_x86.h:168:46: error: ‘p’ was not declared in this scope
  168 |         acc = _mm256_add_ps(_mm256_mul_ps(d, p), acc);
      |                                              ^
[ 52%] Building CXX object CMakeFiles/InferLLM.dir/src/core/model_imp.cpp.o
make[2]: *** [CMakeFiles/InferLLMShared.dir/build.make:251：CMakeFiles/InferLLMShared.dir/src/kern/optimized/kernel_opt.cpp.o] 错误 1
make[2]: *** 正在等待未完成的任务....
[ 55%] Building CXX object CMakeFiles/InferLLM.dir/src/core/op.cpp.o
make[1]: *** [CMakeFiles/Makefile2:184：CMakeFiles/InferLLMShared.dir/all] 错误 2
make[1]: *** 正在等待未完成的任务....
[ 57%] Building CXX object CMakeFiles/InferLLM.dir/src/core/tensor.cpp.o
[ 60%] Building CXX object CMakeFiles/InferLLM.dir/src/core/thread_pool.cpp.o
[ 63%] Building CXX object CMakeFiles/InferLLM.dir/src/file.cpp.o
[ 65%] Building CXX object CMakeFiles/InferLLM.dir/src/graph/chatGLM.cpp.o
[ 68%] Building CXX object CMakeFiles/InferLLM.dir/src/graph/graph_imp.cpp.o
[ 71%] Building CXX object CMakeFiles/InferLLM.dir/src/graph/llama.cpp.o
[ 73%] Building CXX object CMakeFiles/InferLLM.dir/src/kern/naive/naive.cpp.o
[ 76%] Building CXX object CMakeFiles/InferLLM.dir/src/kern/optimized/kernel_opt.cpp.o
[ 78%] Building CXX object CMakeFiles/InferLLM.dir/src/utils.cpp.o
In file included from /mnt/Downloads/InferLLM/src/kern/optimized/kernel_opt.cpp:10:
/mnt/Downloads/InferLLM/src/kern/optimized/x86/optimized_x86.h: In function ‘float inferllm::opt::vec_vec_dot_q40_with_q80(int, const void*, const void*)’:
/mnt/Downloads/InferLLM/src/kern/optimized/x86/optimized_x86.h:168:46: error: ‘p’ was not declared in this scope
  168 |         acc = _mm256_add_ps(_mm256_mul_ps(d, p), acc);
      |                                              ^
make[2]: *** [CMakeFiles/InferLLM.dir/build.make:251：CMakeFiles/InferLLM.dir/src/kern/optimized/kernel_opt.cpp.o] 错误 1
make[2]: *** 正在等待未完成的任务....
make[1]: *** [CMakeFiles/Makefile2:211：CMakeFiles/InferLLM.dir/all] 错误 2
make: *** [Makefile:103：all] 错误 2