### PR TITLE
feat: int8 support

### DIFF
--- a/src/core/graph.cpp
+++ b/src/core/graph.cpp
@@ -223,6 +223,8 @@ DType Graph::convert_dtype(int32_t type) {
             return DType::Int4;
         case 3:
             return DType::Uint4;
+        case 4:
+            return DType::Int8;
         default:
             INFER_ASSERT(0, "unsupported weight type");
     }

--- a/src/kern/kernel_define.h
+++ b/src/kern/kernel_define.h
@@ -16,7 +16,8 @@ using InData = std::vector<const Dtype*>;
 
 enum class KernelID {
     EmbeddingGetInt4Float = 0,
-    EmbeddingGetFloatFloat = 1,
+    EmbeddingGetInt8Float,
+    EmbeddingGetFloatFloat,
     ElemwiseFloat,
     ElemwiseFloatScale,
     ElemwiseBroadcastDim0Src1Float,
@@ -24,6 +25,7 @@ enum class KernelID {
     RmsNormFloat,
     SoftmaxFloat,
     MatmulInt4Float,
+    MatmulInt8Float,
     MatmulFloatFloat,
     MatmulWithHeadStrideFloat,
     //! multi query attention, q*kT

--- a/src/kern/naive/naive.cpp
+++ b/src/kern/naive/naive.cpp
@@ -24,6 +24,22 @@ TaskSet llm_embedding_get_int4_float(
     return TaskSet{{task, len_seq}};
 }
 
+TaskSet llm_embedding_get_int8_float(
+        const void* weights, const uint32_t* index, float* dst, uint32_t len_seq,
+        uint32_t embd) {
+    auto task = [=](const TaskId& id) {
+        for (uint32_t i = id.start; i < id.end; ++i) {
+            const int row = index[i];
+            const int weight_stride =
+                    embd * dtype_in_byte(DType::Int8) / dtype_block_size(DType::Int8);
+            dequantize_row_q8_0_reference(
+                    (static_cast<const char*>(weights) + row * weight_stride),
+                    dst + i * embd, embd);
+        }
+    };
+    return TaskSet{{task, len_seq}};
+}
+
 TaskSet llm_embedding_get_float_float(
         const float* weights, const uint32_t* index, float* dst, uint32_t len_seq,
         uint32_t embd) {
@@ -255,6 +271,41 @@ TaskSet llm_matmul_compute_int4_float(
                 int8_t* src = q_src + m * weight_q80_stride;
                 dst[m * N + n] =
                         vec_vec_dot_q40_with_q80_reference(K, q_weight, src) + b;
+            }
+        }
+    };
+    return TaskSet{{task1, M}, {task2, N}};
+}
+
+TaskSet llm_matmul_compute_int8_float(
+        float* dst, const void* src0, const float* bias, const float* src1, uint32_t M,
+        uint32_t N, uint32_t K, void* workspace, uint32_t size) {
+    //! src0 is quantized weights, weights store in 32 data as block and a block
+    //! share the same scale, src1 is featureMap. src0 layout is {N,
+    //! K}, src1 layout is {M, K}, the dst is {M, N}
+    INFER_ASSERT(sizeof(float) * K <= size, "workspace is not enough.");
+    uint32_t weight_q80_stride =
+            K * dtype_in_byte(DType::Int8) / dtype_block_size(DType::Int8);
+    //! dequantize input, and store in workspace
+    //! becuase the input is small than the weights, quantized the input will
+    //! reduce the memory traffic
+    auto task1 = [=](const TaskId& id) {
+        for (uint32_t m = id.start; m < id.end; m++) {
+            BlockQ80* q_src1 =
+                    (BlockQ80*)(static_cast<uint8_t*>(workspace) + m * weight_q80_stride);
+            quantize_row_q8_0_reference(src1 + m * K, q_src1, K);
+        }
+    };
+    int8_t* q_src = static_cast<int8_t*>(workspace);
+    auto task2 = [=](const TaskId& id) {
+        for (uint32_t n = id.start; n < id.end; n++) {
+            const void* q_weight =
+                    static_cast<const uint8_t*>(src0) + n * weight_q80_stride;
+            float b = bias ? bias[n] : 0.0f;
+            for (uint32_t m = 0; m < M; m++) {
+                int8_t* src = q_src + m * weight_q80_stride;
+                dst[m * N + n] =
+                        vec_vec_dot_q80_with_q80_reference(K, q_weight, src) + b;
             }
         }
     };

--- a/src/kern/naive/naive.h
+++ b/src/kern/naive/naive.h
@@ -11,6 +11,9 @@ namespace naive {
 TaskSet llm_embedding_get_int4_float(
         const void* weights, const uint32_t* index, float* dst, uint32_t len_seq,
         uint32_t embd);
+TaskSet llm_embedding_get_int8_float(
+        const void* weights, const uint32_t* index, float* dst, uint32_t len_seq,
+        uint32_t embd);
 TaskSet llm_embedding_get_float_float(
         const float* weights, const uint32_t* index, float* dst, uint32_t len_seq,
         uint32_t embd);
@@ -36,6 +39,9 @@ TaskSet llm_softmax_compute_float(
 
 // compute the softmax of the last dim of src, and store the result in dst
 TaskSet llm_matmul_compute_int4_float(
+        float* dst, const void* src0, const float* bias, const float* src1, uint32_t M,
+        uint32_t N, uint32_t K, void* workspace, uint32_t size);
+TaskSet llm_matmul_compute_int8_float(
         float* dst, const void* src0, const float* bias, const float* src1, uint32_t M,
         uint32_t N, uint32_t K, void* workspace, uint32_t size);
 TaskSet llm_matmul_compute_float_float(
@@ -103,9 +109,11 @@ PartialImplementKernel(
 PartialImplementKernel(NormFloat, llm_norm_compute_float);
 PartialImplementKernel(RmsNormFloat, llm_rms_norm_compute_float);
 PartialImplementKernel(EmbeddingGetInt4Float, llm_embedding_get_int4_float);
+PartialImplementKernel(EmbeddingGetInt8Float, llm_embedding_get_int8_float);
 PartialImplementKernel(EmbeddingGetFloatFloat, llm_embedding_get_float_float);
 PartialImplementKernel(SoftmaxFloat, llm_softmax_compute_float);
 PartialImplementKernel(MatmulInt4Float, llm_matmul_compute_int4_float);
+PartialImplementKernel(MatmulInt8Float, llm_matmul_compute_int8_float);
 PartialImplementKernel(MatmulFloatFloat, llm_matmul_compute_float_float);
 PartialImplementKernel(
         MatmulWithHeadStrideFloat, llm_matmul_compute_with_head_stride_float);
@@ -125,6 +133,7 @@ PartialImplementKernel(
         HeadBatchedMatmulBroadCastVFloat, llm_head_batched_matmul_broadcastv_float);
 
 PartialImplementSpace(MatmulInt4Float, llm_matmul_get_workspace_float);
+PartialImplementSpace(MatmulInt8Float, llm_matmul_get_workspace_float);
 PartialImplementSpace(MatmulFloatFloat, llm_matmul_get_workspace_float_float);
 
 }  // namespace naive

--- a/src/kern/naive/quantize.h
+++ b/src/kern/naive/quantize.h
@@ -44,7 +44,7 @@ inline void dequantize_row_q8_0_reference(
     const int nb = k / QK80;
     const size_t bs = sizeof(float) + QK40 / 2;
 
-		const BlockQ80* xx = reinterpret_cast<const BlockQ80*>(x);
+    const BlockQ80* xx = reinterpret_cast<const BlockQ80*>(x);
 
     // scalar
     for (int i = 0; i < nb; i++) {
@@ -52,8 +52,8 @@ inline void dequantize_row_q8_0_reference(
 
         const int8_t* __restrict pp = xx[i].qs;
 
-        for (int l = 0; l < QK80; l ++) {
-						y[i * QK80 + l] = pp[l] * d;
+        for (int l = 0; l < QK80; l++) {
+            y[i * QK80 + l] = pp[l] * d;
         }
     }
 }

--- a/src/kern/naive/quantize.h
+++ b/src/kern/naive/quantize.h
@@ -39,6 +39,25 @@ inline void dequantize_row_q4_0_reference(
     }
 }
 
+inline void dequantize_row_q8_0_reference(
+        const void* __restrict x, float* __restrict y, int k) {
+    const int nb = k / QK80;
+    const size_t bs = sizeof(float) + QK40 / 2;
+
+		const BlockQ80* xx = reinterpret_cast<const BlockQ80*>(x);
+
+    // scalar
+    for (int i = 0; i < nb; i++) {
+        const float d = xx[i].d;
+
+        const int8_t* __restrict pp = xx[i].qs;
+
+        for (int l = 0; l < QK80; l ++) {
+						y[i * QK80 + l] = pp[l] * d;
+        }
+    }
+}
+
 inline size_t quantize_row_q4_0_reference(const float* x, BlockQ40* y, int k) {
     const int nb = k / QK40;
 
@@ -129,6 +148,32 @@ inline float vec_vec_dot_q40_with_q80_reference(
             const int i3 = p1[2 * j + 1];
 
             sumi += i0 * i2 + i1 * i3;
+        }
+        sumf += d0 * d1 * sumi;
+    }
+    return sumf;
+}
+
+inline float vec_vec_dot_q80_with_q80_reference(
+        const int n, const void* vx, const void* vy) {
+    const int nb = n / QK80;
+    assert(n % QK80 == 0);
+    assert(nb % 2 == 0);
+
+    const BlockQ80* __restrict x = (BlockQ80*)(vx);
+    const BlockQ80* __restrict y = (BlockQ80*)(vy);
+
+    float sumf = 0.0;
+    for (int i = 0; i < nb; i++) {
+        const float d0 = x[i].d;
+        const float d1 = y[i].d;
+
+        const int8_t* __restrict p0 = x[i].qs;
+        const int8_t* __restrict p1 = y[i].qs;
+
+        int sumi = 0;
+        for (int j = 0; j < QK80; j++) {
+            sumi += p0[j] * p1[j];
         }
         sumf += d0 * d1 * sumi;
     }

--- a/src/kern/optimized/rvv/kernel.h
+++ b/src/kern/optimized/rvv/kernel.h
@@ -9,10 +9,6 @@ namespace opt {
 
 void init();
 
-TaskSet llm_embedding_get_int4_float(
-        const void* weights, const uint32_t* index, float* dst, uint32_t len_seq,
-        uint32_t embd);
-
 TaskSet llm_elemwise_compute_float(
         InData<float> srcs, float* dst, size_t len, ElemMode mode);
 
@@ -28,6 +24,9 @@ TaskSet llm_softmax_compute_float(
 
 // compute the softmax of the last dim of src, and store the result in dst
 TaskSet llm_matmul_compute_int4_float(
+        float* dst, const void* src0, const float* bias, const float* src1, uint32_t M,
+        uint32_t N, uint32_t K, void* workspace, uint32_t size);
+TaskSet llm_matmul_compute_int8_float(
         float* dst, const void* src0, const float* bias, const float* src1, uint32_t M,
         uint32_t N, uint32_t K, void* workspace, uint32_t size);
 
@@ -46,8 +45,8 @@ PartialImplementKernel(ElemwiseFloat, llm_elemwise_compute_float);
 PartialImplementKernel(
         ElemwiseBroadcastDim0Src1Float, llm_elemwise_broadcast_dim0_src1_compute_float);
 PartialImplementKernel(RmsNormFloat, llm_rms_norm_compute_float);
-PartialImplementKernel(EmbeddingGetInt4Float, llm_embedding_get_int4_float);
 PartialImplementKernel(MatmulInt4Float, llm_matmul_compute_int4_float);
+PartialImplementKernel(MatmulInt8Float, llm_matmul_compute_int8_float);
 PartialImplementKernel(
         MatmulWithHeadStrideFloat, llm_matmul_compute_with_head_stride_float);
 PartialImplementKernel(HeadBatchedMatmulFloat, llm_head_batched_matmul_compute_float);


### PR DESCRIPTION
q8 support. It is just faster to run q8 if the platform does not support q4 operations.

Because we have enough memory bandwidth, however, cpu is limited by extra `q4 -> q8` conversion operations.

This can reduce 5 instructions on rv platform, which boosts performance from `1.6 t/s` to `2.8 t/s`. x86 should not have such huge difference, though.

**BTW, I think inferllm should just abort when `dtype` matched an unsupported type.**